### PR TITLE
feat: 카드 컴포넌트 생성 및 태그 컴포넌트 수정

### DIFF
--- a/src/components/cards/Card/Card.stories.tsx
+++ b/src/components/cards/Card/Card.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from "@storybook/react";
+import Card from "./Card";
+import { styled } from "styled-components";
+import theme from "../../../style/theme";
+import { TagProps } from "../../category/Tag/Tag";
+
+const meta: Meta<typeof Card> = {
+  title: "Components/Card",
+  component: Card,
+  tags: ["autodocs"], // 자동으로 문서화를 활성화
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+// 예제 TagProps 생성
+const exampleTagProps: TagProps = {
+  color: {
+    backgroundColor: "blue300",
+    borderColor: "blue100",
+    fontColor: "blue100",
+  },
+};
+
+export const Default: Story = {
+  args: {
+    imageSrc: "https://via.placeholder.com/80",
+    name: "꼬미",
+    age: 3,
+    gender: "암컷",
+    weight: "3.4kg",
+    breed: "말티즈",
+    tags: [
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
+    ],
+  },
+};
+
+// 전역 스타일 wrapper
+const _globalStyleWidth = styled.div`
+  max-width: ${theme.size.maxWidth};
+  min-width: ${theme.size.minWidth};
+`;
+
+export const WithWrapper: Story = {
+  render: (args) => (
+    <_globalStyleWidth>
+      <Card {...args} />
+    </_globalStyleWidth>
+  ),
+  args: {
+    imageSrc: "https://via.placeholder.com/80",
+    name: "꼬미",
+    age: 3,
+    gender: "암컷",
+    weight: "3.4kg",
+    breed: "말티즈",
+    tags: [
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
+    ],
+  },
+};

--- a/src/components/cards/Card/Card.stories.tsx
+++ b/src/components/cards/Card/Card.stories.tsx
@@ -16,11 +16,8 @@ type Story = StoryObj<typeof Card>;
 
 // 예제 TagProps 생성
 const exampleTagProps: TagProps = {
-  color: {
-    backgroundColor: "blue300",
-    borderColor: "blue100",
-    fontColor: "blue100",
-  },
+  backgroundColor: "blue300",
+  fontColor: "blue100",
 };
 
 export const Default: Story = {
@@ -32,6 +29,12 @@ export const Default: Story = {
     weight: "3.4kg",
     breed: "말티즈",
     tags: [
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
       { text: "피부병", tagProps: exampleTagProps },
       { text: "슬개골", tagProps: exampleTagProps },
     ],
@@ -58,6 +61,33 @@ export const WithWrapper: Story = {
     weight: "3.4kg",
     breed: "말티즈",
     tags: [
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
+    ],
+  },
+};
+
+
+export const WithManyTagsWrapper: Story = {
+  render: (args) => (
+    <_globalStyleWidth>
+      <Card {...args} />
+    </_globalStyleWidth>
+  ),
+  args: {
+    imageSrc: "https://via.placeholder.com/80",
+    name: "꼬미",
+    age: 3,
+    gender: "암컷",
+    weight: "3.4kg",
+    breed: "말티즈",
+    tags: [
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
+      { text: "피부병", tagProps: exampleTagProps },
+      { text: "슬개골", tagProps: exampleTagProps },
       { text: "피부병", tagProps: exampleTagProps },
       { text: "슬개골", tagProps: exampleTagProps },
     ],

--- a/src/components/cards/Card/Card.styles.ts
+++ b/src/components/cards/Card/Card.styles.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+import { colors } from '../../../style/color';
+
+export const CardWrapper = styled.div`
+  width: 100%;
+  margin: 0 auto; // 중앙 정렬
+  border: 1px solid ${colors.gray200};
+  border-radius: 8px;
+  padding: 16px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  text-align: center;
+`;
+
+export const TagsWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+export const ProfileImagWrapper = styled.div`
+  flex: 1;
+`;
+
+export const InfoWrapper = styled.div`
+    flex: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-left: 16px;
+`

--- a/src/components/cards/Card/Card.styles.ts
+++ b/src/components/cards/Card/Card.styles.ts
@@ -31,4 +31,11 @@ export const InfoWrapper = styled.div`
     flex-direction: column;
     align-items: flex-start;
     margin-left: 16px;
+    gap: 5px;
+`
+
+export const DiseaseWrapper = styled.div`
+    display: flex;
+    gap: 5px;
+
 `

--- a/src/components/cards/Card/Card.tsx
+++ b/src/components/cards/Card/Card.tsx
@@ -2,7 +2,7 @@ import { Tag } from "../../category/Tag";
 import { TagProps } from "../../category/Tag/Tag";
 import { Text } from "../../texts/Text";
 import ProfileImg from "../../profile-img/ProfileImg";
-import { CardWrapper, InfoWrapper, ProfileImagWrapper, TagsWrapper } from "./Card.styles";
+import { CardWrapper, DiseaseWrapper, InfoWrapper, ProfileImagWrapper, TagsWrapper } from "./Card.styles";
 
 
 export interface TagItem {
@@ -39,13 +39,17 @@ export default function Card({
         <Text color={"gray100"} typo={"body300"}>
           {age}살 | {gender} | {weight} | {breed}
         </Text>
-        <TagsWrapper>
-          {tags.map((tag, index) => (
-            <Tag key={index} {...tag.tagProps}>
-              {tag.text}
-            </Tag>
-          ))}
-        </TagsWrapper>
+        <DiseaseWrapper>
+          <Text typo={"subtitle300"}>질병</Text>
+          <TagsWrapper>
+            {tags.map((tag, index) => (
+              <Tag key={index} {...tag.tagProps}>
+                {tag.text}
+              </Tag>
+            ))}
+          </TagsWrapper>        
+        </DiseaseWrapper>
+
       </InfoWrapper>
     </CardWrapper>
   );

--- a/src/components/cards/Card/Card.tsx
+++ b/src/components/cards/Card/Card.tsx
@@ -1,0 +1,52 @@
+import { Tag } from "../../category/Tag";
+import { TagProps } from "../../category/Tag/Tag";
+import { Text } from "../../texts/Text";
+import ProfileImg from "../../profile-img/ProfileImg";
+import { CardWrapper, InfoWrapper, ProfileImagWrapper, TagsWrapper } from "./Card.styles";
+
+
+export interface TagItem {
+  text: string; // 태그에 표시될 텍스트
+  tagProps: TagProps; // 스타일 정보 포함
+}
+
+interface CardProps {
+  imageSrc: string;
+  name: string;
+  age: number;
+  gender: string;
+  weight: string;
+  breed: string;
+  tags: TagItem[];
+}
+
+export default function Card({
+  imageSrc,
+  name,
+  age,
+  gender,
+  weight,
+  breed,
+  tags,
+}: CardProps) {
+  return (
+    <CardWrapper>
+      <ProfileImagWrapper>
+        <ProfileImg src={imageSrc} alt={`${name}'s image`} width="80px" height="80px" />
+      </ProfileImagWrapper>
+      <InfoWrapper>
+        <Text color={"black"} typo={"subtitle100"}>{name}</Text>
+        <Text color={"gray100"} typo={"body300"}>
+          {age}살 | {gender} | {weight} | {breed}
+        </Text>
+        <TagsWrapper>
+          {tags.map((tag, index) => (
+            <Tag key={index} {...tag.tagProps}>
+              {tag.text}
+            </Tag>
+          ))}
+        </TagsWrapper>
+      </InfoWrapper>
+    </CardWrapper>
+  );
+}

--- a/src/components/cards/Card/index.ts
+++ b/src/components/cards/Card/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Card';

--- a/src/components/category/Tag/Tag.stories.tsx
+++ b/src/components/category/Tag/Tag.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Tag } from "./index";
-import { colors } from "../../../style/color";
 
 // Storybook 메타데이터 설정
 const meta: Meta<typeof Tag> = {
@@ -26,11 +25,9 @@ export const Default: Story = {
 export const CustomColorTag: Story = {
   args: {
     children: "커스텀 색상 태그", // children으로 전달
-    color: {
-      backgroundColor: "red300", // 빨간 배경
-      borderColor: "red100", // 빨간 테두리
-      fontColor: "red100", // 빨간 폰트
-    },
+    backgroundColor: "red300", // 빨간 배경
+    borderColor: "red100", // 빨간 테두리
+    fontColor: "red100", // 빨간 폰트
   },
 };
 

--- a/src/components/category/Tag/Tag.stories.tsx
+++ b/src/components/category/Tag/Tag.stories.tsx
@@ -27,9 +27,9 @@ export const CustomColorTag: Story = {
   args: {
     children: "커스텀 색상 태그", // children으로 전달
     color: {
-      backgroundColor: colors.white, // 황금색 배경
-      borderColor: colors.gray300, // 주황색 테두리
-      fontColor: colors.gray300, // 흰색 폰트
+      backgroundColor: "red300", // 빨간 배경
+      borderColor: "red100", // 빨간 테두리
+      fontColor: "red100", // 빨간 폰트
     },
   },
 };

--- a/src/components/category/Tag/Tag.styles.ts
+++ b/src/components/category/Tag/Tag.styles.ts
@@ -16,5 +16,5 @@ export const TagWrapper = styled.div<TagStyleProps>`
 
   /* 색상 관련 스타일링 */
   background-color: ${({ backgroundColor }) => backgroundColor ? colors[backgroundColor] : colors.blue300};
-  border: 1px solid ${({ borderColor }) => borderColor ? colors[borderColor] : colors.gray300};
+  border:  ${({ borderColor }) => borderColor ? `1px solid ${colors[borderColor]}` : null};
 `;

--- a/src/components/category/Tag/Tag.styles.ts
+++ b/src/components/category/Tag/Tag.styles.ts
@@ -5,18 +5,19 @@ import { colors } from "../../../style/color";
 
 interface TagStyleProps {
   color?: {
-    backgroundColor?: string;
-    borderColor?: string;
-    fontColor?: string;
+    backgroundColor?: keyof typeof colors;
+    borderColor?: keyof typeof colors;
+    fontColor?: keyof typeof colors;
   };
 }
 
 export const TagWrapper = styled.div<TagStyleProps>`
-  color: ${({ color }) => color?.fontColor || colors.blue200}; /* 폰트 색상 */
-  border: 1px solid ${({ color }) => color?.borderColor || colors.blue200}; /* border 색상 */
-  border-radius: 5px;
-  background-color: ${({ color }) =>
-    color?.backgroundColor || colors.blue100}; /* 배경 색상 */
   padding: 3px 10px;
-  font-weight: 500;
+  ${typography.body300};
+  border-radius: 5px;
+  text-align: center;
+
+  /* 색상 관련 스타일링 */
+  background-color: ${({ color }) => color?.backgroundColor ? colors[color.backgroundColor] : colors.blue300};
+  border: 1px solid ${({ color }) => color?.borderColor ? colors[color.borderColor] : colors.gray300};
 `;

--- a/src/components/category/Tag/Tag.styles.ts
+++ b/src/components/category/Tag/Tag.styles.ts
@@ -4,11 +4,8 @@ import { typography } from "../../../style/typography";
 import { colors } from "../../../style/color";
 
 interface TagStyleProps {
-  color?: {
-    backgroundColor?: keyof typeof colors;
-    borderColor?: keyof typeof colors;
-    fontColor?: keyof typeof colors;
-  };
+  backgroundColor?: keyof typeof colors;
+  borderColor?: keyof typeof colors;
 }
 
 export const TagWrapper = styled.div<TagStyleProps>`
@@ -18,6 +15,6 @@ export const TagWrapper = styled.div<TagStyleProps>`
   text-align: center;
 
   /* 색상 관련 스타일링 */
-  background-color: ${({ color }) => color?.backgroundColor ? colors[color.backgroundColor] : colors.blue300};
-  border: 1px solid ${({ color }) => color?.borderColor ? colors[color.borderColor] : colors.gray300};
+  background-color: ${({ backgroundColor }) => backgroundColor ? colors[backgroundColor] : colors.blue300};
+  border: 1px solid ${({ borderColor }) => borderColor ? colors[borderColor] : colors.gray300};
 `;

--- a/src/components/category/Tag/Tag.tsx
+++ b/src/components/category/Tag/Tag.tsx
@@ -2,15 +2,18 @@
 import React from "react";
 import { TagWrapper } from "./Tag.styles";
 import { Text } from "../../texts/Text";
+import { colors } from "../../../style/color";
 
-interface TagProps {
+type Color = keyof typeof colors;
+
+export interface TagProps {
   /**
    * 스타일 옵션: 색상 지정
    */
   color?: {
-    backgroundColor?: string;
-    borderColor?: string;
-    fontColor?: string;
+    backgroundColor?: Color;
+    borderColor?: Color;
+    fontColor?: Color;
   };
 }
 
@@ -20,7 +23,7 @@ export default function Tag({
 }: React.PropsWithChildren<TagProps>) {
   return (
     <TagWrapper color={color}>
-      <Text typo="body300">{children}</Text>
+      <Text typo="body300" color={color?.fontColor}>{children}</Text>
     </TagWrapper>
   );
 }

--- a/src/components/category/Tag/Tag.tsx
+++ b/src/components/category/Tag/Tag.tsx
@@ -10,20 +10,20 @@ export interface TagProps {
   /**
    * 스타일 옵션: 색상 지정
    */
-  color?: {
-    backgroundColor?: Color;
-    borderColor?: Color;
-    fontColor?: Color;
-  };
+  backgroundColor?: Color;
+  borderColor?: Color;
+  fontColor?: Color;
 }
 
 export default function Tag({
   children,
-  color,
+  backgroundColor,
+  borderColor,
+  fontColor
 }: React.PropsWithChildren<TagProps>) {
   return (
-    <TagWrapper color={color}>
-      <Text typo="body300" color={color?.fontColor}>{children}</Text>
+    <TagWrapper backgroundColor={backgroundColor} borderColor={borderColor}>
+      <Text typo="body300" color={fontColor}>{children}</Text>
     </TagWrapper>
   );
 }

--- a/src/components/texts/Text/Text.styles.ts
+++ b/src/components/texts/Text/Text.styles.ts
@@ -10,6 +10,7 @@ interface StyledTextProps {
 
 // 스타일 정의
 export const StyledText = styled.span<StyledTextProps>`
+  align-content: center;
   color: ${({ color }) =>
     color ? colors[color] : colors.gray100}; // 기본값은 black
   ${({ typo }) => typography[typo]}// typography 스타일 적용


### PR DESCRIPTION
## Card, Tag 컴포넌트 생성
- 카드 및 태그의 스타일이 적용이 안되어있어서 수정했습니다. 
### Card 
![스크린샷 2024-11-30 오후 10 22 52](https://github.com/user-attachments/assets/470c956f-9393-4cbd-a043-0056cf6e42e8)

### Tag
![스크린샷 2024-11-30 오후 10 23 16](https://github.com/user-attachments/assets/010048c0-8916-4009-8a58-5ecaefbf15c5)



## Text 컴포넌트 수정
- Text 컴포넌트에 `align-content: center;` 속성을 추가했습니다. 
### 수정 전
![스크린샷 2024-11-30 오후 10 24 28](https://github.com/user-attachments/assets/fbfdce67-482c-4178-a7f4-9868564a442b)

### 수정 후
![스크린샷 2024-11-30 오후 10 25 18](https://github.com/user-attachments/assets/13def057-6d74-4c67-89c2-754dec4ebaab)
