### PR TITLE
Fix: Chromatic 테스트 겸 Button width 수정

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,65 @@
+name: Preview
+
+on:
+  pull_request:
+    branches: ["feature/**"]
+
+permissions:
+  contents: write
+  pages: write
+  deployments: write
+  id-token: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  storybook-preview:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 저장소 체크아웃
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: 캐시 종속성
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}-storybook
+
+      - name: 종속성 설치
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install
+
+      - name: Chromatic에 게시
+        id: chromatic
+        uses: chromaui/action@v1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          onlyChanged: true
+          autoAcceptChanges: true
+
+      - name: 현재 시간 가져오기
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: "YYYY년 MM월 DD일 HH시 mm분 ss초"
+          utcOffset: "+09:00"
+
+    outputs:
+      storybook_url: ${{ steps.chromatic.outputs.storybookUrl }}
+      currnent_time: ${{ steps.current-time.outputs.formattedTime }}
+
+  github-bot-storybook:
+    runs-on: ubuntu-latest
+    needs: [storybook-preview]
+    steps:
+      - name: PR 코멘트 남기기
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          comment_tag: ${{github.event.number}}-storybook
+          message: |
+            💄 Storybook: ${{ needs.storybook-preview.outputs.storybook_url }}
+            🕖 Update: ${{ needs.storybook-preview.outputs.currnent_time }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -32,6 +32,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install
 
+      # 기존 Chromatic Action
       - name: Chromatic에 게시
         id: chromatic
         uses: chromaui/action@v1

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "svgr": "npx @svgr/cli -d src/assets/svg --ignore-existing --typescript --no-dimensions public/svg",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "chromatic": "npx chromatic --project-token=chpt_bbf18d311f19e2d"
   },
   "dependencies": {
     "@eslint/plugin-kit": "^0.2.3",
@@ -44,6 +45,7 @@
     "@types/react-modal": "^3",
     "@types/styled-components": "^5.1.34",
     "@vitejs/plugin-react": "^4.3.3",
+    "chromatic": "^11.20.0",
     "eslint": "^9.13.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",

--- a/src/components/button/CustomButton/CustomButton.styles.ts
+++ b/src/components/button/CustomButton/CustomButton.styles.ts
@@ -59,7 +59,7 @@ export const Button = styled.button<{
           /* padding: 12px 24px; */
           ${typography.subtitle200}
           height: 60px;
-          width: 90%;
+          width: 100%;
         `;
     }
   }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2450,6 +2450,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chromatic@npm:^11.20.0":
+  version: 11.20.0
+  resolution: "chromatic@npm:11.20.0"
+  peerDependencies:
+    "@chromatic-com/cypress": ^0.*.* || ^1.0.0
+    "@chromatic-com/playwright": ^0.*.* || ^1.0.0
+  peerDependenciesMeta:
+    "@chromatic-com/cypress":
+      optional: true
+    "@chromatic-com/playwright":
+      optional: true
+  bin:
+    chroma: dist/bin.js
+    chromatic: dist/bin.js
+    chromatic-cli: dist/bin.js
+  checksum: 10c0/26e63794b38f3b76ea8b4f2ad2fc47057a049f76a684d44a3b541a774c50d7bed901c885cb60e4baf5df26d37574c20faaea897bc38f8606949456ba6d9eab2a
+  languageName: node
+  linkType: hard
+
 "clean-stack@npm:^2.0.0":
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
@@ -4970,6 +4989,7 @@ __metadata:
     "@types/styled-components": "npm:^5.1.34"
     "@vitejs/plugin-react": "npm:^4.3.3"
     axios: "npm:^1.7.7"
+    chromatic: "npm:^11.20.0"
     eslint: "npm:^9.13.0"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-config-standard: "npm:^17.1.0"


### PR DESCRIPTION
# 사용하면서 배우는 Chromatic! 
부제: Button width 90% -> 100% 수정 https://github.com/peauty/peauty-FE/pull/47/commits/38045dba7f41dc14cf592211dd9753528f59d910

## 이게 뭔가요?
스토리북을 무료로 배포해주고.. 
PR을 올리면 컴포넌트의 UI가 어떻게 바뀌었는지 diff를 시각적으로 보여주고.. 
또 그곳에서도 리뷰를 할 수 있는... 그런것.

## 왜 갑자기 이걸?
아까 시언이가 캐러셀 PR 올렸는데 지하철에서 PR을 보다가 이거 PR에서 자동으로 컴포넌트 볼 수 있음 좋겠당..
뭔가 있을거 같은데? 해서 찾아보니 있음. 그래서 적용함.

## 아하
밑에 있는 깃허브 링크는 스토리북에 배포된 컴포넌트 링크입니다.
이거 기능을 좀 더 알고 사용하면 좋은점 많을거 같습니다. 같이 써보면서 개선해봅시다. 이상.

## 어떻게 사용?
일단 깃허브 계정으로 가입이 필요합니다. (https://www.chromatic.com/) 
가입하고, 우리 레포 연동하고 슉슉 하다보면 PR올릴때마다 뭐 체크해야한다고 보일겁니다. 이것저것 눌러보시면 됩니다. 저도 아직 자세히는 모릅니다. 
![스크린샷 2024-12-03 오후 9 34 57](https://github.com/user-attachments/assets/efb7a161-8dc3-43f5-9b27-42970d33f274)
PR을 올리면 위와같이 chromatic에서 생성한 액션들이 보이는데, `Details`를 클릭해서 리뷰를 해봅시다.

홈페이지: https://www.chromatic.com/
유튜브 데모링크: https://youtu.be/zhrboql8UuU