### PR TITLE
feat: designer api, type 추가

### DIFF
--- a/src/apis/resources/designer/index.ts
+++ b/src/apis/resources/designer/index.ts
@@ -1,0 +1,53 @@
+import { CustomerAPI } from "../../api";
+import { GetDesignerWorkspaceResponse } from "../../../types/designer";
+import { UpdateDesignerWorkspaceResponse } from "../../../types/designer";
+import { UpdateDesignerWorkspaceRequest } from "../../../types/designer";
+import { CreateDesignerWorkspaceResponse } from "../../../types/designer";
+import { CreateDesignerWorkspaceRequest } from "../../../types/designer";
+import { GetDesignerProfileResponse } from "../../../types/designer";
+import { UpdateDesignerProfileResponse } from "../../../types/designer";
+import { UpdateDesignerProfileRequest } from "../../../types/designer";
+import { UploadProfileImageResponse } from "../../../types/designer";
+import FormData from "form-data";
+import { CheckDesignerNicknameDuplicatedResponse } from "../../../types/designer";
+
+export const getDesignerWorkspace = async (userId: number): Promise<GetDesignerWorkspaceResponse> => {
+  const res = await CustomerAPI.get<GetDesignerWorkspaceResponse>(`/v1/users/${userId}/shop`);
+  return res.data;
+};
+
+export const updateDesignerWorkspace = async (userId: number, data: UpdateDesignerWorkspaceRequest): Promise<UpdateDesignerWorkspaceResponse> => {
+  const res = await CustomerAPI.put<UpdateDesignerWorkspaceResponse>(`/v1/users/${userId}/shop`, data);
+  return res.data;
+};
+
+export const createDesignerWorkspace = async (userId: number, data: CreateDesignerWorkspaceRequest): Promise<CreateDesignerWorkspaceResponse> => {
+  const res = await CustomerAPI.post<CreateDesignerWorkspaceResponse>(`/v1/users/${userId}/shop`, data);
+  return res.data;
+};
+
+export const getDesignerProfile = async (userId: number): Promise<GetDesignerProfileResponse> => {
+  const res = await CustomerAPI.get<GetDesignerProfileResponse>(`/v1/users/${userId}/profile`);
+  return res.data;
+};
+
+export const updateDesignerProfile = async (userId: number, data: UpdateDesignerProfileRequest): Promise<UpdateDesignerProfileResponse> => {
+  const res = await CustomerAPI.put<UpdateDesignerProfileResponse>(`/v1/users/${userId}/profile`, data);
+  return res.data;
+};
+
+export const uploadProfileImage = async (userId: number, image: File): Promise<UploadProfileImageResponse> => {
+  const formData = new FormData();
+  formData.append("image", image);
+  const res = await CustomerAPI.post<UploadProfileImageResponse>(`/v1/users/${userId}/profile/images`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+  return res.data;
+};
+
+export const checkDesignerNicknameDuplicatedResponse = async (query: { nickname: string }): Promise<CheckDesignerNicknameDuplicatedResponse> => {
+  const res = await CustomerAPI.get<CheckDesignerNicknameDuplicatedResponse>(`/v1/users/check`, { params: query });
+  return res.data;
+};

--- a/src/apis/resources/internal/index.ts
+++ b/src/apis/resources/internal/index.ts
@@ -1,11 +1,23 @@
 import { CustomerAPI } from "../../api";
-import { UploadImageResponse } from "../../../types/internal";
+import { UploadImagesResponse } from "../../../types/internal";
 import FormData from "form-data";
+import { UploadImageResponse } from "../../../types/internal";
+
+export const uploadImages = async (): Promise<UploadImagesResponse> => {
+  const formData = new FormData();
+  formData.append("image", image);
+  const res = await CustomerAPI.post<UploadImagesResponse>(`/v1/internal/images`, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+  return res.data;
+};
 
 export const uploadImage = async (image: File): Promise<UploadImageResponse> => {
   const formData = new FormData();
   formData.append("image", image);
-  const res = await CustomerAPI.post<UploadImageResponse>(`/v1/internal/images`, formData, {
+  const res = await CustomerAPI.post<UploadImageResponse>(`/v1/internal/image`, formData, {
     headers: {
       'Content-Type': 'multipart/form-data',
     },

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -5,10 +5,10 @@ export interface SignUpResponse {
 
 export interface SignUpRequest {
   socialId?: string;
-  socialPlatform?: 'KAKAO' | 'GOOGLE' | 'APPLE' | '';
+  socialPlatform?: 'KAKAO' | 'GOOGLE' | 'APPLE';
   name?: string;
-  phoneNum?: string;
-  address?: string;
+  phoneNumber?: string;
+  email?: string;
   nickname?: string;
   profileImageUrl?: string;
 }

--- a/src/types/designer/index.ts
+++ b/src/types/designer/index.ts
@@ -1,0 +1,148 @@
+export interface GetDesignerWorkspaceResponse {
+  designerId?: number;
+  workspaceId?: number;
+  bannerImageUrl?: string;
+  workspaceName?: string;
+  reviewRating?: number;
+  reviewsCount?: number;
+  scissors?: 'NONE' | 'GOLD' | 'SILVER' | 'BRONZE';
+  introduceTitle?: string;
+  introduce?: string;
+  noticeTitle?: string;
+  notice?: string;
+  address?: string;
+  addressDetail?: string;
+  phoneNumber?: string;
+  yearOfExperience?: number;
+  openHours?: string;
+  closeHours?: string;
+  openDay?: string;
+  directionGuide?: string;
+  licenses?: string[];
+  paymentOptions?: 'CARD' | 'CASH' | 'ACCOUNT'[];
+  representativeBadgeNames?: string[];
+}
+
+export interface UpdateDesignerWorkspaceResponse {
+  designerId?: number;
+  workspaceId?: number;
+  bannerImageUrl?: string;
+  workspaceName?: string;
+  reviewRating?: number;
+  reviewsCount?: number;
+  scissor?: 'NONE' | 'GOLD' | 'SILVER' | 'BRONZE';
+  introduceTitle?: string;
+  introduce?: string;
+  noticeTitle?: string;
+  notice?: string;
+  address?: string;
+  addressDetail?: string;
+  phoneNumber?: string;
+  yearOfExperience?: number;
+  openHours?: string;
+  closeHours?: string;
+  openDay?: string;
+  directionGuide?: string;
+  licenses?: string[];
+  paymentOptions?: 'CARD' | 'CASH' | 'ACCOUNT'[];
+  representativeBadgeNames?: string[];
+}
+
+export interface UpdateDesignerWorkspaceRequest {
+  bannerImageUrl?: string;
+  workspaceName?: string;
+  introduceTitle?: string;
+  introduce?: string;
+  noticeTitle?: string;
+  notice?: string;
+  address?: string;
+  addressDetail?: string;
+  yearOfExperience?: number;
+  licenses?: string[];
+  paymentOptions?: 'CARD' | 'CASH' | 'ACCOUNT'[];
+  openHours?: string;
+  closeHours?: string;
+  openDays?: string;
+  directionGuide?: string;
+  phoneNumber?: string;
+}
+
+export interface CreateDesignerWorkspaceResponse {
+  designerId?: number;
+  workspaceId?: number;
+  bannerImageUrl?: string;
+  workspaceName?: string;
+  reviewRating?: number;
+  reviewsCount?: number;
+  scissor?: 'NONE' | 'GOLD' | 'SILVER' | 'BRONZE';
+  introduceTitle?: string;
+  introduce?: string;
+  noticeTitle?: string;
+  notice?: string;
+  address?: string;
+  addressDetail?: string;
+  phoneNumber?: string;
+  yearOfExperience?: number;
+  openHours?: string;
+  closeHours?: string;
+  openDay?: string;
+  directionGuide?: string;
+  licenses?: string[];
+  paymentOptions?: 'CARD' | 'CASH' | 'ACCOUNT'[];
+  representativeBadgeNames?: string[];
+}
+
+export interface CreateDesignerWorkspaceRequest {
+  bannerImageUrl?: string;
+  workspaceName?: string;
+  introduceTitle?: string;
+  introduce?: string;
+  noticeTitle?: string;
+  notice?: string;
+  address?: string;
+  addressDetail?: string;
+  yearOfExperience?: number;
+  licenses?: string[];
+  paymentOptions?: 'CARD' | 'CASH' | 'ACCOUNT'[];
+  openHours?: string;
+  closeHours?: string;
+  openDays?: string;
+  directionGuide?: string;
+  phoneNumber?: string;
+}
+
+export interface GetDesignerProfileResponse {
+  designerId?: number;
+  name?: string;
+  nickname?: string;
+  profileImageUrl?: string;
+  email?: string;
+  phoneNum?: string;
+}
+
+export interface UpdateDesignerProfileResponse {
+  designerId?: number;
+  name?: string;
+  nickname?: string;
+  phoneNum?: string;
+  profileImageUrl?: string;
+  email?: string;
+}
+
+export interface UpdateDesignerProfileRequest {
+  name?: string;
+  nickname?: string;
+  phoneNum?: string;
+  address?: string;
+  profileImageUrl?: string;
+  email?: string;
+}
+
+export interface UploadProfileImageResponse {
+  designerId?: number;
+  uploadedProfileImageUrl?: string;
+}
+
+export interface CheckDesignerNicknameDuplicatedResponse {
+  message?: string;
+}

--- a/src/types/internal/index.ts
+++ b/src/types/internal/index.ts
@@ -1,3 +1,7 @@
+export interface UploadImagesResponse {
+  uploadedImageUrl?: string[];
+}
+
 export interface UploadImageResponse {
   uploadedImageUrl?: string;
 }


### PR DESCRIPTION
swagger 기반하여  designer api, type 추가하였습니다.
다만 현재 `API 및 Type 생성 스크립트`는 API 및, Type을 Swagger에서 내려준대로 덮어쓰게 되어있으므로 덮어쓰지 않게 하려면 추가설정이 필요합니다. 

# API 및 Type 생성 스크립트 
swagger에서 API 및 type을 가져와서 리소스별로 생성합니다.