### PR TITLE
[PEAUTY-151] input 컴포넌트에서 input과 textarea 둘 다 선택적으로 사용할 수 있도록 type 추가

### DIFF
--- a/src/components/input/CustomInput/CustomInput.styles.ts
+++ b/src/components/input/CustomInput/CustomInput.styles.ts
@@ -53,12 +53,10 @@ export const InputWrapper = styled.div<{
   ${({ variant, error, disabled }) =>
     variant === "outlined"
       ? css`
-          border-radius: 5px;
           border: ${disabled
             ? `1px solid ${colors.blue100}`
             : `1px solid ${error ? colors.red200 : colors.gray400}`};
           padding: 0px 10px;
-          height: 50px;
           border-radius: 10px;
 
           &:focus-within {
@@ -71,8 +69,6 @@ export const InputWrapper = styled.div<{
           border-bottom: 1px solid ${error ? colors.red200 : colors.gray300};
           border-radius: 0;
           padding: 5px 10px;
-          height: 50px;
-          border-radius: 10px;
 
           &:focus-within {
             border-bottom-color: ${error ? colors.red200 : colors.blue200};
@@ -85,7 +81,30 @@ export const StyledInput = styled.input<{ error: boolean }>`
   outline: none;
   background-color: transparent;
   font-size: 14px;
-  padding-left: 10px;
+  padding: 12px 10px;
+
+  &::placeholder {
+    color: #9ca3af;
+    font-size: ${typography.body100};
+  }
+
+  &:disabled {
+    color: ${colors.black};
+    cursor: not-allowed;
+    font-size: 12px;
+  }
+`;
+
+export const StyledTextarea = styled.textarea<{ error: boolean }>`
+  flex: 1;
+  outline: none;
+  background-color: transparent;
+  font-size: 14px;
+  padding: 10px;
+  min-height: 120px;
+  resize: none;
+  line-height: 1.6;
+  border: none;
 
   &::placeholder {
     color: #9ca3af;

--- a/src/components/input/CustomInput/CustomInput.tsx
+++ b/src/components/input/CustomInput/CustomInput.tsx
@@ -1,16 +1,17 @@
-import { InputHTMLAttributes, ReactNode, useState } from "react";
+import { InputHTMLAttributes, useState, ReactNode } from "react";
 import {
   Container,
   Label,
   InputWrapper,
   StyledInput,
+  StyledTextarea,
   SuffixContainer,
   Message,
 } from "./CustomInput.styles";
-import Text from "../../texts/Text/Text";
+import { Text } from "../../texts/Text";
 
 interface CustomInputProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, "size"> {
+  extends InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
   width?: string;
   label?: string;
   error?: string;
@@ -20,6 +21,7 @@ interface CustomInputProps
   variant?: "outlined" | "underlined";
   suffix?: ReactNode;
   hasButton?: boolean;
+  inputType?: "input" | "textarea"; // input인지 textarea인지 구분
 }
 
 export default function CustomInput({
@@ -32,6 +34,7 @@ export default function CustomInput({
   variant = "outlined",
   suffix,
   hasButton = false,
+  inputType = "input", // 기본값 input
   ...props
 }: CustomInputProps) {
   // focused 상태 관리
@@ -51,13 +54,18 @@ export default function CustomInput({
         onFocus={() => setFocused(true)} // 포커스 상태 설정
         onBlur={() => setFocused(false)} // 포커스 해제 시 상태 변경
       >
-        <StyledInput error={!!error} disabled={disabled} {...props} />
+        {inputType === "input" ? (
+          <StyledInput error={!!error} disabled={disabled} {...props} />
+        ) : (
+          <StyledTextarea error={!!error} disabled={disabled} {...props} />
+        )}
         {suffix && (
           <SuffixContainer variant={variant} error={!!error}>
             {suffix}
           </SuffixContainer>
         )}
       </InputWrapper>
+
       {(error || hint || success) && (
         <Message error={!!error}>
           <Text

--- a/src/pages/designer/signup-detail/index.tsx
+++ b/src/pages/designer/signup-detail/index.tsx
@@ -40,47 +40,24 @@ export default function DesignerSignUpDetail() {
           <Style.TitleWrapper>
             <Text typo="subtitle300">공지사항</Text>
             <Text color="gray100" typo="body500">
-              현재 진행 중인 이벤트가 있다면 등록해 주세요
-            </Text>
-          </Style.TitleWrapper>
-
-          <CustomInput
-            error=""
-            hint=""
-            label="제목"
-            placeholder="공지사항의 제목을 입력해주세요"
-            variant="outlined"
-          />
-          <CustomInput
-            error=""
-            hint=""
-            label="내용"
-            placeholder="공지사항의 내용을 입력해주세요"
-            variant="outlined"
-          />
-        </Style.SectionWrapper>
-        <Style.SectionWrapper>
-          <Style.TitleWrapper>
-            <Text typo="subtitle300">이벤트</Text>
-            <Text color="gray100" typo="body500">
               매장 운영과 관련된 특이 사항이 있으시면 등록해 주세요
             </Text>
           </Style.TitleWrapper>
 
-          <CustomInput
-            error=""
-            hint=""
-            label="제목"
-            placeholder="이벤트 제목을 입력해주세요"
-            variant="outlined"
-          />
-          <CustomInput
-            error=""
-            hint=""
-            label="내용"
-            placeholder="이벤트 내용을 입력해주세요"
-            variant="outlined"
-          />
+          <CustomInput placeholder="제목을 입력해주세요" />
+          <CustomInput placeholder="내용을 입력해주세요" inputType="textarea" />
+        </Style.SectionWrapper>
+        <Style.SectionWrapper>
+          <Style.TitleWrapper>
+            <Text typo="subtitle300">이벤트</Text>
+
+            <Text color="gray100" typo="body500">
+              현재 진행 중인 이벤트가 있다면 등록해 주세요
+            </Text>
+          </Style.TitleWrapper>
+
+          <CustomInput placeholder="제목을 입력해주세요" />
+          <CustomInput placeholder="내용을 입력해주세요" inputType="textarea" />
         </Style.SectionWrapper>
 
         <Style.SectionWrapper>


### PR DESCRIPTION
### 💻 작업 내용
> 어떤 기능을 개발했나요?
 input 컴포넌트에서 input과 textarea 둘 다 선택적으로 사용할 수 있도록 type 추가했습니다

사용 방법
![image](https://github.com/user-attachments/assets/c7e159bd-42a9-447f-833f-f7b57919d445)
 inputType을 "input" | "textarea" 두가지로 나눠서 사용할 수 있으며, 기본 값은 Input로 설정해두었습니다.

### 📷 이미지 첨부
![image](https://github.com/user-attachments/assets/06e438c6-52c3-4ffc-9b8b-8d1507ca7a85)

### 🧠 PR 체크
- [x] 담당자와 리뷰어를 설정했어요. 
- [x] label을 설정했어요.
