### PR TITLE
[PEAUTY-159] 홈 경로를 Intro로 변경

### DIFF
--- a/src/pages/intro/index.tsx
+++ b/src/pages/intro/index.tsx
@@ -9,9 +9,23 @@ import {
 import { CustomButton } from "../../components/button/CustomButton";
 import { Text } from "../../components";
 import { ROUTE } from "../../constants/routes";
+import { useUserDetails } from "../../hooks/useUserDetails";
+import { useEffect } from "react";
 
 const Intro = () => {
   const navigate = useNavigate();
+  const {role, isLoading } = useUserDetails();
+
+  useEffect(()=>{
+    if (!isLoading) {
+      if (role === "ROLE_CUSTOMER") {
+        navigate(ROUTE.customer.home)
+      } else if (role === "ROLE_DESIGNER") {
+        console.log() 
+        // navigate(ROUTE.designer.home) // TODO
+      }
+    }
+  }, [isLoading]) 
 
   const handleStartClick = () => {
     navigate(ROUTE.signIn);

--- a/src/router/root/index.tsx
+++ b/src/router/root/index.tsx
@@ -3,7 +3,7 @@ import SignIn from "../../pages/sign-in";
 
 export const rootPaths = [
     {
-      path: "intro",
+      path: "",
       element: <Intro/>
     },
     {


### PR DESCRIPTION
## [PEAUTY-159] 홈 경로를 Intro로 변경

### 📢 관련 이슈
https://lgsw1.slack.com/archives/C080A3C0UMC/p1733571233411679

### 💻 작업 내용
> 
- 홈 경로를 intro로 변경
- intro 진입시 토큰을 확인하여 미용사 또는 유저 홈으로 이동

### 🧠 PR 체크
`완료하셨다면 띄어쓰기 대신 [] 사이에 소문자 x로 표시해주세요.`
- [x] 담당자와 리뷰어를 설정했어요. 
- [x] label을 설정했어요.
