### PR TITLE
[PEAUTY-192]: 디자이너 추가정보 이미지 업로드 API 연동

### DIFF
--- a/src/assets/svg/AddImage.tsx
+++ b/src/assets/svg/AddImage.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import type { SVGProps } from "react";
 const SvgAddImage = (props: SVGProps<SVGSVGElement>) => (
   <svg

--- a/src/pages/designer/signup-detail/components/CoverPhotoUploadSection.tsx
+++ b/src/pages/designer/signup-detail/components/CoverPhotoUploadSection.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { AddImage } from "../../../../assets/svg";
 import { CustomButton, Text } from "../../../../components";
 import { Style } from "../index.styles";
+import { uploadImage } from "../../../../apis/designer/resources/internal";
 
 interface CoverPhotoUploadSectionProps {
   onChange: (url: string) => void;
@@ -10,12 +11,26 @@ interface CoverPhotoUploadSectionProps {
 export default function CoverPhotoUploadSection({
   onChange,
 }: CoverPhotoUploadSectionProps) {
-  const [imageUrl, setImageUrl] = useState<string>("");
+  const [imageUrls, setImageUrls] = useState<string[]>([]);
 
-  const handleImageUpload = async () => {
-    const uploadedUrl = ""; // 예시 URL
-    setImageUrl(uploadedUrl);
-    onChange(uploadedUrl); // 상위 컴포넌트에 이미지 URL 전달
+  const handleImageUpload = async (file: File) => {
+    try {
+      const response = await uploadImage(file);
+      if (response.uploadedImageUrl) {
+        const updatedImageUrls = [...imageUrls, response.uploadedImageUrl];
+        setImageUrls(updatedImageUrls);
+        onChange(response.uploadedImageUrl); // 상위 컴포넌트에 최신 이미지 URL 전달
+      }
+    } catch (error) {
+      console.error("Image upload failed:", error);
+    }
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      handleImageUpload(file);
+    }
   };
 
   return (
@@ -26,11 +41,31 @@ export default function CoverPhotoUploadSection({
           이미지 등록은 최대 3장까지 가능해요
         </Text>
 
-        <Style.AddWrapper>
-          <CustomButton variant="secondary" onClick={handleImageUpload}>
-            <AddImage width={15} />
-          </CustomButton>
-        </Style.AddWrapper>
+        <Style.ImageContainer>
+          {/* 추가 버튼 */}
+          {imageUrls.length < 3 && (
+            <Style.AddWrapper>
+              <CustomButton variant="secondary">
+                <label htmlFor="image-upload" style={{ cursor: "pointer" }}>
+                  <AddImage width={15} />
+                </label>
+                <input
+                  id="image-upload"
+                  type="file"
+                  accept="image/*"
+                  style={{ display: "none" }}
+                  onChange={handleFileChange}
+                />
+              </CustomButton>
+            </Style.AddWrapper>
+          )}
+          {/* 업로드된 이미지 */}
+          {imageUrls.map((url, index) => (
+            <Style.AddWrapper key={index}>
+              <Style.ImageUnit src={url} alt={`Uploaded image ${index + 1}`} />
+            </Style.AddWrapper>
+          ))}
+        </Style.ImageContainer>
       </Style.TitleWrapper>
     </Style.SectionWrapper>
   );

--- a/src/pages/designer/signup-detail/components/CoverPhotoUploadSection.tsx
+++ b/src/pages/designer/signup-detail/components/CoverPhotoUploadSection.tsx
@@ -5,7 +5,7 @@ import { Style } from "../index.styles";
 import { uploadImage } from "../../../../apis/designer/resources/internal";
 
 interface CoverPhotoUploadSectionProps {
-  onChange: (url: string) => void;
+  onChange: (url: string[]) => void; // 여러 이미지 URL을 전달하도록 수정
 }
 
 export default function CoverPhotoUploadSection({
@@ -19,7 +19,7 @@ export default function CoverPhotoUploadSection({
       if (response.uploadedImageUrl) {
         const updatedImageUrls = [...imageUrls, response.uploadedImageUrl];
         setImageUrls(updatedImageUrls);
-        onChange(response.uploadedImageUrl); // 상위 컴포넌트에 최신 이미지 URL 전달
+        onChange(updatedImageUrls); // 상위 컴포넌트에 전체 이미지 URL 목록 전달
       }
     } catch (error) {
       console.error("Image upload failed:", error);
@@ -31,6 +31,12 @@ export default function CoverPhotoUploadSection({
     if (file) {
       handleImageUpload(file);
     }
+  };
+
+  const handleImageDelete = (url: string) => {
+    const updatedImageUrls = imageUrls.filter((imageUrl) => imageUrl !== url);
+    setImageUrls(updatedImageUrls);
+    onChange(updatedImageUrls); // 상위 컴포넌트에 삭제된 목록 전달
   };
 
   return (
@@ -61,8 +67,12 @@ export default function CoverPhotoUploadSection({
           )}
           {/* 업로드된 이미지 */}
           {imageUrls.map((url, index) => (
-            <Style.AddWrapper key={index}>
+            <Style.AddWrapper key={index} style={{ position: "relative" }}>
               <Style.ImageUnit src={url} alt={`Uploaded image ${index + 1}`} />
+              {/* 삭제 버튼 */}
+              <Style.DeleteButton onClick={() => handleImageDelete(url)}>
+                &minus;
+              </Style.DeleteButton>
             </Style.AddWrapper>
           ))}
         </Style.ImageContainer>

--- a/src/pages/designer/signup-detail/index.styles.ts
+++ b/src/pages/designer/signup-detail/index.styles.ts
@@ -36,4 +36,15 @@ export const Style = {
     width: 60px;
     margin-top: 10px;
   `,
+  ImageContainer: styled.div`
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+  `,
+
+  ImageUnit: styled.img`
+    width: 100%;
+    height: 50px;
+    border-radius: 10px;
+  `,
 };

--- a/src/pages/designer/signup-detail/index.styles.ts
+++ b/src/pages/designer/signup-detail/index.styles.ts
@@ -47,4 +47,21 @@ export const Style = {
     height: 50px;
     border-radius: 10px;
   `,
+
+  DeleteButton: styled.button`
+    position: absolute;
+    top: -5px;
+    right: -5px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background-color: red;
+    color: white;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    cursor: pointer;
+  `,
 };


### PR DESCRIPTION
## [PEAUTY-192]: 디자이너 추가정보 이미지 업로드 API 연동

### 📢 관련 이슈
- 이미지 업로드 API 연동

### 💻 작업 내용
- 이미지 업로드 후 url을 받아서 사진에 업데이트
- 이미지 삭제 또한 추가 (제거해도 됌)

### 📷 이미지 
<img width="342" alt="스크린샷 2024-12-10 오후 9 49 21" src="https://github.com/user-attachments/assets/6de93f68-40bb-409d-9c5c-28340d3e6b7e">
<img width="277" alt="스크린샷 2024-12-10 오후 9 49 33" src="https://github.com/user-attachments/assets/8e1f0709-36bd-412a-a000-f2fcd11f591c">


### 🧠 PR 체크
`완료하셨다면 띄어쓰기 대신 [] 사이에 소문자 x로 표시해주세요.`
- [x] 담당자와 리뷰어를 설정했어요. 
- [x] label을 설정했어요.
