### PR TITLE
[PEAUTY-201] DateDrop Box 컴포넌트 생성

### DIFF
--- a/src/components/button/DateDropBox/DateDropBox.styles.ts
+++ b/src/components/button/DateDropBox/DateDropBox.styles.ts
@@ -1,0 +1,78 @@
+import styled from "styled-components";
+import { colors } from "../../../style/color";
+import { typography } from "../../../style/typography";
+import { DownArrow, UpArrow } from "../../../assets/svg";
+
+export const Wrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const Label = styled.label`
+  ${typography.subtitle300};
+  margin-bottom: 8px;
+  display: inline-block;
+`;
+
+export const DropdownContainer = styled.div<{ isActive: boolean }>`
+  display: flex;
+  align-items: center;
+  height: 50px;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border: 1px solid
+    ${({ isActive }) => (isActive ? colors.blue100 : colors.gray300)};
+  border-radius: 10px;
+  cursor: pointer;
+  background-color: #fff;
+  transition: border-color 0.3s;
+
+  &:hover {
+    border-color: ${colors.blue100};
+  }
+
+  svg {
+    margin-left: 8px;
+  }
+`;
+
+export const Placeholder = styled.span`
+  font-size: 14px;
+  color: ${colors.gray100};
+`;
+
+export const SelectedValue = styled.span`
+  font-size: 14px;
+  color: ${colors.black};
+`;
+
+export const DropdownList = styled.ul`
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  width: 100%;
+  border: 1px solid ${colors.gray300};
+  border-radius: 10px;
+  background-color: #fff;
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 10;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  list-style: none;
+  padding: 0;
+  margin: 0;
+`;
+
+export const DropdownListItem = styled.li`
+  padding: 10px 12px;
+  font-size: 14px;
+  color: ${colors.gray100};
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${colors.blue100};
+    color: #fff;
+  }
+`;

--- a/src/components/button/DateDropBox/DateDropBox.tsx
+++ b/src/components/button/DateDropBox/DateDropBox.tsx
@@ -103,7 +103,7 @@ export const CustomDatePicker: React.FC<CustomDatePickerProps> = ({
                   <SelectedValue>{selected}</SelectedValue>
                 ) : (
                   <Placeholder>
-                    {type === "year" ? "연도" : type === "month" ? "월" : "일"}
+                    {type === "year" ? "년" : type === "month" ? "월" : "일"}
                   </Placeholder>
                 )}
                 {activeDropdown === type ? (

--- a/src/components/button/DateDropBox/DateDropBox.tsx
+++ b/src/components/button/DateDropBox/DateDropBox.tsx
@@ -1,0 +1,148 @@
+import React, { useState, useRef, useEffect } from "react";
+import {
+  Wrapper,
+  Label,
+  DropdownContainer,
+  Placeholder,
+  SelectedValue,
+  DropdownList,
+  DropdownListItem,
+} from "./DateDropBox.styles";
+import { DownArrow, UpArrow } from "../../../assets/svg";
+interface CustomDatePickerProps {
+  label?: string;
+  type: "birthday" | "reservation";
+  onChange?: (date: string) => void;
+}
+export const CustomDatePicker: React.FC<CustomDatePickerProps> = ({
+  label,
+  type,
+  onChange = () => {},
+}) => {
+  const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+  const [selectedYear, setSelectedYear] = useState<string | null>(null);
+  const [selectedMonth, setSelectedMonth] = useState<string | null>(null);
+  const [selectedDay, setSelectedDay] = useState<string | null>(null);
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const currentYear = new Date().getFullYear();
+  const years =
+    type === "birthday"
+      ? [
+          "선택 없음",
+          ...Array.from({ length: currentYear - 1994 + 1 }, (_, i) =>
+            (1994 + i).toString(),
+          ),
+        ]
+      : [
+          "선택 없음",
+          ...Array.from({ length: 2 }, (_, i) => (currentYear + i).toString()),
+        ];
+
+  const months = [
+    "선택 없음",
+    ...Array.from({ length: 12 }, (_, i) =>
+      (i + 1).toString().padStart(2, "0"),
+    ),
+  ];
+
+  const days = [
+    "선택 없음",
+    ...Array.from({ length: 31 }, (_, i) =>
+      (i + 1).toString().padStart(2, "0"),
+    ),
+  ];
+
+  const handleDateChange = () => {
+    if (selectedYear && selectedMonth && selectedDay) {
+      const formattedDate = `${selectedYear}-${selectedMonth}-${selectedDay}`;
+      onChange(formattedDate);
+    }
+  };
+
+  const closeDropdowns = (event: MouseEvent) => {
+    if (
+      dropdownRef.current &&
+      !dropdownRef.current.contains(event.target as Node)
+    ) {
+      setActiveDropdown(null);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", closeDropdowns);
+    return () => {
+      document.removeEventListener("mousedown", closeDropdowns);
+    };
+  }, []);
+
+  return (
+    <Wrapper ref={dropdownRef}>
+      {label && <Label>{label}</Label>}
+      <div style={{ display: "flex", gap: "8px" }}>
+        {["year", "month", "day"].map((type, index) => {
+          const options =
+            type === "year" ? years : type === "month" ? months : days;
+          const selected =
+            type === "year"
+              ? selectedYear
+              : type === "month"
+                ? selectedMonth
+                : selectedDay;
+
+          return (
+            <div style={{ position: "relative", flex: 1 }} key={type}>
+              <DropdownContainer
+                isActive={activeDropdown === type}
+                onClick={() =>
+                  setActiveDropdown((prev) => (prev === type ? null : type))
+                }
+              >
+                {selected ? (
+                  <SelectedValue>{selected}</SelectedValue>
+                ) : (
+                  <Placeholder>
+                    {type === "year" ? "연도" : type === "month" ? "월" : "일"}
+                  </Placeholder>
+                )}
+                {activeDropdown === type ? (
+                  <UpArrow height={12} />
+                ) : (
+                  <DownArrow height={12} />
+                )}
+              </DropdownContainer>
+              {activeDropdown === type && (
+                <DropdownList>
+                  {options.map((option) => (
+                    <DropdownListItem
+                      key={option}
+                      onClick={() => {
+                        if (type === "year")
+                          setSelectedYear(
+                            option === "선택 없음" ? null : option,
+                          );
+                        if (type === "month")
+                          setSelectedMonth(
+                            option === "선택 없음" ? null : option,
+                          );
+                        if (type === "day")
+                          setSelectedDay(
+                            option === "선택 없음" ? null : option,
+                          );
+                        setActiveDropdown(null);
+                        handleDateChange();
+                      }}
+                    >
+                      {option}
+                    </DropdownListItem>
+                  ))}
+                </DropdownList>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </Wrapper>
+  );
+};


### PR DESCRIPTION
## [PEAUTY-201] DateDrop Box 컴포넌트 생성
`제목도 동일하게 작성해주세요`

### 📢 관련 이슈


### 💻 작업 내용
> 어떤 기능을 개발했나요?
DropDown을 통해 날짜를 선택할 수 있도록 만들었습니다.

사용하시는 곳에서   
```
const handleDateChange = (date: string) => {
    setSelectedDate(date);
    console.log("선택된 날짜:", date);
  };
```
와 같은 것으로 확인해보시면 "2024-11-03" 형식으로 찍힙니다.

백엔드에서 "-"으로 날짜 구분을 해서 나이를 계산해주고 내려주기 때문에 위와 같이 통일했습니다.

### 📷 이미지 첨부
더 자세한 설명을 위해 첨부하실 이미지가 있다면 첨부해주세요.

![image](https://github.com/user-attachments/assets/2eb1246d-8107-4017-bb52-37285c063419)


```
   <DateDropBox
            type="reservation"
            label="날짜"
            onChange={handleDateChange}
          />
```
```
   <DateDropBox
            type="birthday"
            label="날짜"
            onChange={handleDateChange}
          />
```


첫번째로 사용하시면 현재 년도 기준 1년
두번째는 1994년부터 현재 년도까지 날짜 설정할수 있습니다.
### 🧠 PR 체크
`완료하셨다면 띄어쓰기 대신 [] 사이에 소문자 x로 표시해주세요.`
- [x] 담당자와 리뷰어를 설정했어요. 
- [x] label을 설정했어요.
