### PR TITLE
[PEAUTY-178] 영문화된 svg와 스타일 연결

### DIFF
--- a/src/pages/customer/request/customize-grooming/index.tsx
+++ b/src/pages/customer/request/customize-grooming/index.tsx
@@ -53,20 +53,17 @@ export default function CustomizeGrooming() {
   const [desiredDateTimeError, setDesiredDateTimeError] = useState("");
   const [selectedDate, setSelectedDate] = useState("");
 
-  const maxCharLimit = 300;
+  const maxCharLimit = 200;
 
-  const faceStyleImg: Record<
-    string,
-    React.FC<React.SVGProps<SVGSVGElement>>
-  > = {
-    EggHead,
-    BabyCut,
-    Goddess,
-    TeddyCut,
-    SealCut,
-    LionCut,
-    Helmet,
-    EarsPop,
+  const faceStyleImg: Record<string, JSX.Element> = {
+    알머리컷: <EggHead width="100px" height="auto" />,
+    베이비컷: <BabyCut width="100px" height="auto" />,
+    여신머리: <Goddess width="100px" height="auto" />,
+    곰돌이컷: <TeddyCut width="100px" height="auto" />,
+    물개컷: <SealCut width="100px" height="auto" />,
+    라이언컷: <LionCut width="100px" height="auto" />,
+    하이바컷: <Helmet width="100px" height="auto" />,
+    귀툭튀: <EarsPop width="100px" height="auto" />,
   };
 
   const handleGroomingTypeSelect = (index: number) => {
@@ -147,12 +144,7 @@ export default function CustomizeGrooming() {
                 onSelect={handleFaceStyleSelect}
               />
               {selectedFaceStyle && selectedFaceStyle !== "선택 없음" && (
-                <SelectedHair>
-                  {faceStyleImg[selectedFaceStyle]?.({
-                    width: "100px",
-                    height: "auto",
-                  })}
-                </SelectedHair>
+                <SelectedHair>{faceStyleImg[selectedFaceStyle]}</SelectedHair>
               )}
             </SectionWrapper>
 


### PR DESCRIPTION
## [PEAUTY-178] 영문화된 svg와 스타일 연결
`제목도 동일하게 작성해주세요`

### 📢 관련 이슈


### 💻 작업 내용
> 어떤 기능을 개발했나요?

svg와 헤어스타일이 동일하도록 수정했습니다.
### 📷 이미지 첨부
더 자세한 설명을 위해 첨부하실 이미지가 있다면 첨부해주세요.
![image](https://github.com/user-attachments/assets/3e3241ae-72e4-418c-86d7-be58654d674a)

### 🧠 PR 체크
`완료하셨다면 띄어쓰기 대신 [] 사이에 소문자 x로 표시해주세요.`
- [x] 담당자와 리뷰어를 설정했어요. 
- [x] label을 설정했어요.
