### PR TITLE
[PEAUTY-226] Shop 라이센스 이미지 연결

### DIFF
--- a/src/apis/resources/designer/index.ts
+++ b/src/apis/resources/designer/index.ts
@@ -15,7 +15,7 @@ export const getDesignerWorkspace = async (
   userId: number,
 ): Promise<GetDesignerWorkspaceResponse> => {
   const res = await CustomerAPI.get<GetDesignerWorkspaceResponse>(
-    `/v1/${userId}/shop`,
+    `/v1/users/${userId}/shop`, // 경로 수정: users 추가
   );
   return res.data;
 };

--- a/src/pages/shop/components/ShopBadge/index.tsx
+++ b/src/pages/shop/components/ShopBadge/index.tsx
@@ -39,7 +39,7 @@ export const ShopBadge = forwardRef<HTMLDivElement, ShopBadgeProps>(
       <BadgeContainer ref={ref} {...props}>
         <Text typo="subtitle300">가게 뱃지</Text>
         <BadgeGrid>
-          {badges.map((badge) => (
+          {badges?.map((badge) => (
             <BadgeItem
               key={badge.badgeId}
               onClick={() => handleBadgeClick(badge)}
@@ -56,7 +56,7 @@ export const ShopBadge = forwardRef<HTMLDivElement, ShopBadgeProps>(
             </BadgeItem>
           ))}
         </BadgeGrid>
-        {badges.length === 0 && (
+        {badges?.length === 0 && (
           <Text typo="body400" color="gray100">
             뱃지가 없습니다.
           </Text>

--- a/src/pages/shop/components/ShopDetail/License/index.styles.ts
+++ b/src/pages/shop/components/ShopDetail/License/index.styles.ts
@@ -2,13 +2,12 @@ import styled from "styled-components";
 import { colors } from "../../../../../style/color";
 
 export const ImageWrapper = styled.div`
-    display: flex;
-    margin-top: 15px;
-    gap: 5px;
+  display: flex;
+  margin-top: 15px;
+  gap: 5px;
 `;
 
-export const ImageItem = styled.img`
-width: 85px;
-height: 80px;
-border: 1px solid ${colors.gray300};
-`
+export const ImageItem = styled.div`
+  width: 85px;
+  height: 80px;
+`;

--- a/src/pages/shop/components/ShopDetail/License/index.tsx
+++ b/src/pages/shop/components/ShopDetail/License/index.tsx
@@ -1,16 +1,40 @@
 import { Text } from "../../../../../components";
 import { ContentsWrapper } from "../../index.styles";
 import { ImageWrapper, ImageItem } from "./index.styles";
-export default function License() {
+
+interface LicenseProps {
+  licenses?: string[];
+}
+
+export default function License({ licenses = [] }: LicenseProps) {
   return (
     <ContentsWrapper>
       <Text typo="subtitle300">자격증 및 기타 서류</Text>
-      <ImageWrapper>
-        <ImageItem
-        ></ImageItem>
-        <ImageItem
-        ></ImageItem>
-      </ImageWrapper>
+      {licenses.length > 0 ? (
+        <ImageWrapper>
+          {licenses.map((licenseUrl, index) => (
+            <ImageItem key={index}>
+              <img
+                src={licenseUrl}
+                alt={`license-${index}`}
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  objectFit: "cover",
+                }}
+              />
+            </ImageItem>
+
+            // </ImageItem>
+          ))}
+        </ImageWrapper>
+      ) : (
+        <div>
+          <Text typo="body400" color="gray100">
+            등록된 자격증이 없어요
+          </Text>
+        </div>
+      )}
     </ContentsWrapper>
   );
 }

--- a/src/pages/shop/components/ShopDetail/index.tsx
+++ b/src/pages/shop/components/ShopDetail/index.tsx
@@ -17,6 +17,7 @@ const ShopDetail = forwardRef<HTMLDivElement, ShopDetailProps>(
       openDay,
       paymentOptions,
       phoneNumber,
+      licenses,
       ...rest
     },
     ref,
@@ -34,7 +35,7 @@ const ShopDetail = forwardRef<HTMLDivElement, ShopDetailProps>(
           phoneNumber={phoneNumber}
         />
         <Career yearOfExperience={yearOfExperience} />
-        <License />
+        <License licenses={licenses} />
       </TabWrapper>
     );
   },

--- a/src/pages/shop/components/ShopOverview/OverviewInfo/index.tsx
+++ b/src/pages/shop/components/ShopOverview/OverviewInfo/index.tsx
@@ -43,14 +43,20 @@ export default function OverviewInfo({
           <Text typo="body400">{introduce}</Text>
         </div>
         <IconContain>
-          {representativeBadges.map((badge, index) => (
-            <Badge
-              key={index}
-              type={badge.badgeType.toLowerCase()}
-              text={badge.badgeName}
-              variant={badge.badgeColor.toLowerCase()}
-            />
-          ))}
+          {representativeBadges && representativeBadges.length > 0 ? (
+            representativeBadges.map((badge, index) => (
+              <Badge
+                key={index}
+                type={badge.badgeType?.toLowerCase() || "default"} // badgeType이 없을 경우 기본값 설정
+                text={badge.badgeName || "Unknown"} // badgeName이 없을 경우 기본값 설정
+                variant={badge.badgeColor?.toLowerCase() || "gray"} // badgeColor가 없을 경우 기본값 설정
+              />
+            ))
+          ) : (
+            <Text typo="body400" color="gray100">
+              {""}
+            </Text>
+          )}
         </IconContain>
       </TextWrapper>
     </InfoWrapper>

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -7,7 +7,7 @@ import ShopDetail from "./components/ShopDetail";
 import ShopReview from "./components/ShopReview";
 import { ShopBadge } from "./components/ShopBadge";
 import { StickyContainer } from "./index.styles";
-import { getDesignerWorkspace } from "../../apis/resources/designer";
+import { getDesignerWorkspace } from "../../apis/designer/resources/designer";
 import { useParams } from "react-router-dom";
 
 type Section = "detail" | "review" | "badge";
@@ -28,8 +28,8 @@ export default function Shop() {
       id === "detail"
         ? detailRef.current
         : id === "review"
-        ? reviewRef.current
-        : badgeRef.current;
+          ? reviewRef.current
+          : badgeRef.current;
 
     if (target) {
       const navHeight = navRef.current?.offsetHeight || 0;
@@ -68,10 +68,12 @@ export default function Shop() {
   useEffect(() => {
     const handleScroll = () => {
       const detailTop = detailRef.current?.getBoundingClientRect().top || 0;
-      const detailBottom = detailRef.current?.getBoundingClientRect().bottom || 0;
+      const detailBottom =
+        detailRef.current?.getBoundingClientRect().bottom || 0;
 
       const reviewTop = reviewRef.current?.getBoundingClientRect().top || 0;
-      const reviewBottom = reviewRef.current?.getBoundingClientRect().bottom || 0;
+      const reviewBottom =
+        reviewRef.current?.getBoundingClientRect().bottom || 0;
 
       const badgeTop = badgeRef.current?.getBoundingClientRect().top || 0;
       const badgeBottom = badgeRef.current?.getBoundingClientRect().bottom || 0;
@@ -126,6 +128,7 @@ export default function Shop() {
     openDay: workspace.openDay,
     paymentOptions: workspace.paymentOptions,
     phoneNumber: workspace.phoneNumber,
+    licenses: workspace.licenses,
   };
 
   return (

--- a/src/types/customer/request/index.tsx
+++ b/src/types/customer/request/index.tsx
@@ -31,6 +31,7 @@ export interface ShopDetailProps {
   openDay: string;
   paymentOptions: string[];
   phoneNumber: string;
+  licenses: string[];
 }
 export interface ShopDetailInfoProps {
   workspaceName: string;

--- a/src/types/designer/designer/index.ts
+++ b/src/types/designer/designer/index.ts
@@ -8,28 +8,28 @@ export interface Badge {
 }
 
 export interface GetDesignerWorkspaceResponse {
-  designerId: number;
-  workspaceId: number;
-  bannerImageUrl: string;
-  workspaceName: string;
-  reviewRating: number;
-  reviewsCount: number;
-  scissors: "NONE" | "GOLD" | "SILVER" | "BRONZE";
-  introduceTitle: string;
-  introduce: string;
-  noticeTitle: string;
-  notice: string;
-  address: string;
-  addressDetail: string;
-  phoneNumber: string;
-  yearOfExperience: number;
-  openHours: string;
-  closeHours: string;
-  openDay: string;
-  directionGuide: string;
-  licenses: string[]; // 자격증 이미지 URL 리스트
-  paymentOptions: ("계좌 이체" | "현금 결제" | "카드 결제")[]; // 결제 옵션
-  representativeBadgeNames: Badge[]; // 대표 배지 이름 리스트
+  designerId?: number;
+  workspaceId?: number;
+  bannerImageUrl?: string;
+  workspaceName?: string;
+  reviewRating?: number;
+  reviewsCount?: number;
+  scissors?: "NONE" | "GOLD" | "SILVER" | "BRONZE";
+  introduceTitle?: string;
+  introduce?: string;
+  noticeTitle?: string;
+  notice?: string;
+  address?: string;
+  addressDetail?: string;
+  phoneNumber?: string;
+  yearOfExperience?: number;
+  openHours?: string;
+  closeHours?: string;
+  openDay?: string;
+  directionGuide?: string;
+  licenses?: string[]; // 자격증 이미지 URL 리스트
+  paymentOptions?: ("계좌 이체" | "현금 결제" | "카드 결제")[]; // 결제 옵션
+  representativeBadgeNames?: Badge[]; // 대표 배지 이름 리스트
 }
 
 export interface UpdateDesignerWorkspaceResponse {


### PR DESCRIPTION
## [PEAUTY-226] Shop 라이센스 이미지 연결
`제목도 동일하게 작성해주세요`

### 📢 관련 이슈


### 💻 작업 내용
> 어떤 기능을 개발했나요?

라이센스 이미지를 연결하고 뱃지나, 라이센스가 없는 경우에 대한 처리도 했습니다.
### 📷 이미지 첨부
더 자세한 설명을 위해 첨부하실 이미지가 있다면 첨부해주세요.
![image](https://github.com/user-attachments/assets/1617a331-6fc6-4c2d-9d45-4f40b9375182)

### 🧠 PR 체크
`완료하셨다면 띄어쓰기 대신 [] 사이에 소문자 x로 표시해주세요.`
- [x] 담당자와 리뷰어를 설정했어요. 
- [x] label을 설정했어요.
